### PR TITLE
reduce build time by removing some experimental tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine AS builder
 WORKDIR /go/src/app
-COPY . /go/src/app
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -tags timetzdata -o timezones main.go
+COPY ./main.go /go/src/app
+RUN CGO_ENABLED=0 GOOS=linux go build -tags timetzdata -o timezones main.go
 EXPOSE 8080
 
 FROM scratch


### PR DESCRIPTION
reduced tags to make the docker builds faster